### PR TITLE
return 404 when guid could not be found

### DIFF
--- a/cfshim/filters/app_filter.go
+++ b/cfshim/filters/app_filter.go
@@ -17,7 +17,7 @@ func (a *AppFilter) Filter(input interface{}) bool {
 		fmt.Printf("Error, could not cast filter input to app\n")
 		return false
 	}
-	fmt.Printf("AppFilter cast to App successful: %v", *app)
+	//fmt.Printf("AppFilter cast to App successful: %v", *app)
 
 	// Take the URL input list and compare to the field in the App K8s CR Object
 	if !queryParameterMatches(a.QueryParameters["guids"], app.ObjectMeta.Name) {

--- a/cfshim/handlers/app_handler.go
+++ b/cfshim/handlers/app_handler.go
@@ -55,6 +55,11 @@ func (a *AppHandler) GetAppsHandler(w http.ResponseWriter, r *http.Request) {
 		formattedApps = append(formattedApps, formatApp(app))
 	}
 
+	if len(formattedApps) < 1 {
+		// If no matches for the GUID, just return a 404
+		w.WriteHeader(404)
+		return
+	}
 	// Write MatchedApps to http ResponseWriter
 	w.Header().Set("Content-Type", "application/json")
 	// We are only printing the first element in the list for now ignoring cross-namespace guid collisions


### PR DESCRIPTION
@angelachin noticed an issue with the GET guid endpoint nor returning a response when no app with the corresponding guid exists. The code expected at least one match and was failing due to a runtime error.

I have updated the logic to return a 404 if the list of matches is zero length.

```
curl "http://localhost:81/v3/apps/" -v
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 81 (#0)
> GET /v3/apps/ HTTP/1.1
> Host: localhost:81
> User-Agent: curl/7.64.1
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< Date: Mon, 14 Jun 2021 22:35:51 GMT
< Content-Length: 0
< 
* Connection #0 to host localhost left intact
* Closing connection 0
```