### PR TITLE
Add endpoints to start and stop an App

### DIFF
--- a/api/v1alpha1/app_types.go
+++ b/api/v1alpha1/app_types.go
@@ -34,7 +34,7 @@ type AppSpec struct {
 	// Valid values are:
 	// "STARTED": App is started
 	// "STOPPED": App is stopped
-	State DesiredState `json:"state"`
+	DesiredState DesiredState `json:"desiredState"`
 
 	// Specifies the CF Lifecycle type:
 	// https://v3-apidocs.cloudfoundry.org/version/3.101.0/index.html#sample-requests

--- a/cfshim/handlers/app_handler.go
+++ b/cfshim/handlers/app_handler.go
@@ -12,7 +12,7 @@ import (
 
 	"encoding/json"
 
-	appsv1alpha1 "cloudfoundry.org/cf-crd-explorations/api/v1alpha1"
+	cfappsv1alpha1 "cloudfoundry.org/cf-crd-explorations/api/v1alpha1"
 	"github.com/google/uuid"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,9 +21,10 @@ import (
 
 // Define the routes used in the REST endpoints
 const (
-	AppsEndpoint      = "/v3/apps"
-	GetAppEndpoint    = AppsEndpoint + "/{guid}"
-	SetCurrentDroplet = GetAppEndpoint + "/relationships/current_droplet"
+	AppsEndpoint               = "/v3/apps"
+	GetAppEndpoint             = AppsEndpoint + "/{guid}"
+	SetCurrentDroplet          = GetAppEndpoint + "/relationships/current_droplet"
+	SetAppDesiredStateEndpoint = GetAppEndpoint + "/actions/{action}"
 )
 
 type AppHandler struct {
@@ -144,7 +145,7 @@ func (a *AppHandler) CreateAppsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		formatQueryParams(queryParameters)
 
-		var matchedApps []*appsv1alpha1.App
+		var matchedApps []*cfappsv1alpha1.App
 
 		// Apply filter to AllApps and store result in matchedApps
 		matchedApps, err := getAppListFromQuery(&a.Client, queryParameters)
@@ -218,19 +219,19 @@ func (a *AppHandler) CreateAppsHandler(w http.ResponseWriter, r *http.Request) {
 		envSecret = appGUID + "-env"
 	}
 
-	app := &appsv1alpha1.App{
+	app := &cfappsv1alpha1.App{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        appGUID,
 			Namespace:   appRequest.Relationships.Space.Data.GUID,
 			Labels:      appRequest.Metadata.Labels,
 			Annotations: appRequest.Metadata.Annotations,
 		},
-		Spec: appsv1alpha1.AppSpec{
-			Name:  appRequest.Name,
-			State: "STOPPED",
-			Type:  appsv1alpha1.LifecycleType(lifecycleType),
-			Lifecycle: appsv1alpha1.Lifecycle{
-				Data: appsv1alpha1.LifecycleData{
+		Spec: cfappsv1alpha1.AppSpec{
+			Name:         appRequest.Name,
+			DesiredState: "STOPPED",
+			Type:         cfappsv1alpha1.LifecycleType(lifecycleType),
+			Lifecycle: cfappsv1alpha1.Lifecycle{
+				Data: cfappsv1alpha1.LifecycleData{
 					Buildpacks: lifecycleData.Buildpacks,
 					Stack:      lifecycleData.Stack,
 				},
@@ -259,7 +260,7 @@ func (a *AppHandler) UpdateAppsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	formatQueryParams(queryParameters)
 
-	var matchedApps []*appsv1alpha1.App
+	var matchedApps []*cfappsv1alpha1.App
 
 	// Apply filter to AllApps and store result in matchedApps
 	matchedApps, err := getAppListFromQuery(&a.Client, queryParameters)
@@ -323,7 +324,7 @@ func (a *AppHandler) UpdateAppsHandler(w http.ResponseWriter, r *http.Request) {
 		stack = appRequest.Lifecycle.Data.Stack
 	}
 
-	matchedApps[0].Spec.Lifecycle.Data = appsv1alpha1.LifecycleData{
+	matchedApps[0].Spec.Lifecycle.Data = cfappsv1alpha1.LifecycleData{
 		Buildpacks: buildpacks,
 		Stack:      stack,
 	}
@@ -340,7 +341,7 @@ func (a *AppHandler) UpdateAppsHandler(w http.ResponseWriter, r *http.Request) {
 
 func (a *AppHandler) SetCurrentDroplet(w http.ResponseWriter, r *http.Request) {
 
-	var matchedApps []*appsv1alpha1.App
+	var matchedApps []*cfappsv1alpha1.App
 	var dropletRequest CFAPIAppRelationshipsDroplet
 	var errorMessage string
 	var errorTitle string
@@ -392,7 +393,7 @@ func (a *AppHandler) SetCurrentDroplet(w http.ResponseWriter, r *http.Request) {
 	}
 	formatQueryParams(queryParameters)
 
-	var matchedDroplets []*appsv1alpha1.Droplet
+	var matchedDroplets []*cfappsv1alpha1.Droplet
 	matchedDroplets, err = getDropletListFromQuery(&a.Client, queryParameters)
 	if err != nil {
 		fmt.Printf("error fetching droplets from query: %s\n", err)
@@ -433,7 +434,7 @@ func (a *AppHandler) SetCurrentDroplet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	matchedApp.Spec.CurrentDropletRef = appsv1alpha1.DropletReference{
+	matchedApp.Spec.CurrentDropletRef = cfappsv1alpha1.DropletReference{
 		Name: dropletRequest.Data.GUID,
 	}
 
@@ -453,10 +454,65 @@ func (a *AppHandler) SetCurrentDroplet(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(formatSetDropletResponse(matchedApp))
 }
 
-func (a *AppHandler) ReturnFormattedResponse(w http.ResponseWriter, app *appsv1alpha1.App) {
+func (a *AppHandler) ReturnFormattedResponse(w http.ResponseWriter, app *cfappsv1alpha1.App) {
 	formattedApp := formatAppToPresenter(app)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(201)
 	json.NewEncoder(w).Encode(formattedApp)
+}
+
+// SetAppDesiredStateHandler is for getting a single app from the guid
+// For now, only outputs the first match after searching ALL namespaces for Apps
+// POST /v3/apps/:guid/actions/start|stop
+// https://v3-apidocs.cloudfoundry.org/version/3.101.0/index.html#start-an-app
+// https://v3-apidocs.cloudfoundry.org/version/3.101.0/index.html#stop-an-app
+func (a *AppHandler) SetAppDesiredStateHandler(w http.ResponseWriter, r *http.Request) {
+	//Fetch the {guid} value from URL using gorilla mux
+	vars := mux.Vars(r)
+	appGUID := vars["guid"]
+	action := vars["action"]
+	desiredState := cfappsv1alpha1.StartedState
+
+	if action != "start" && action != "stop" {
+		ReturnFormattedError(w, 500, "ServerError", fmt.Sprintf("action %s is not recognized", action), 10001)
+		return
+	} else if action == "stop" {
+		desiredState = cfappsv1alpha1.StoppedState
+	}
+
+	// map[string][]string
+	queryParameters := map[string][]string{
+		"guids": {appGUID},
+	}
+
+	// Use the k8s client to fetch the apps with the same metadata.name as the guid
+	matchedApps, err := getAppListFromQuery(&a.Client, queryParameters)
+	if err != nil {
+		ReturnFormattedError(w, 500, "ServerError", err.Error(), 10001)
+		return
+	}
+
+	if len(matchedApps) < 1 {
+		// If no matches for the GUID, just return a 404
+		w.WriteHeader(404)
+		return
+	}
+
+	matchedApp := matchedApps[0]
+	if matchedApp.Spec.DesiredState != desiredState {
+		// modify the desired state of the app and re-apply it
+		matchedApp.Spec.DesiredState = desiredState
+		err = a.Client.Update(context.Background(), matchedApp)
+		if err != nil {
+			fmt.Printf("error updating App object: %v\n", err)
+			w.WriteHeader(500)
+			return
+		}
+	}
+
+	// Write MatchedApps to http ResponseWriter
+	w.Header().Set("Content-Type", "application/json")
+	// We are only printing the first element in the list for now ignoring cross-namespace guid collisions
+	a.ReturnFormattedResponse(w, matchedApp)
 }

--- a/cfshim/handlers/app_handler.go
+++ b/cfshim/handlers/app_handler.go
@@ -495,7 +495,11 @@ func (a *AppHandler) SetAppDesiredStateHandler(w http.ResponseWriter, r *http.Re
 
 	if len(matchedApps) < 1 {
 		// If no matches for the GUID, just return a 404
-		w.WriteHeader(404)
+		errorMessage := fmt.Sprintf("App with guid %s not found", appGUID)
+		errorTitle := "CF-ResourceNotFound"
+		errorCode := 10010
+		errorHeader := 404
+		ReturnFormattedError(w, errorHeader, errorTitle, errorMessage, errorCode)
 		return
 	}
 

--- a/cfshim/handlers/presenter_types.go
+++ b/cfshim/handlers/presenter_types.go
@@ -79,7 +79,7 @@ func formatAppToPresenter(app *appsv1alpha1.App) CFAPIPresenterAppResource {
 	toReturn := CFAPIPresenterAppResource{
 		GUID:      app.Name,
 		Name:      app.Spec.Name,
-		State:     string(app.Spec.State),
+		State:     string(app.Spec.DesiredState),
 		CreatedAt: app.CreationTimestamp.UTC().Format(time.RFC3339),
 		UpdatedAt: "",
 		Lifecycle: CFAPIPresenterAppLifecycle{

--- a/config/crd/bases/apps.cloudfoundry.org_apps.yaml
+++ b/config/crd/bases/apps.cloudfoundry.org_apps.yaml
@@ -46,6 +46,12 @@ spec:
                 - kind
                 - name
                 type: object
+              desiredState:
+                description: 'Specifies the current state of the app Valid values are: "STARTED": App is started "STOPPED": App is stopped'
+                enum:
+                - STARTED
+                - STOPPED
+                type: string
               envSecretName:
                 description: Specifies the k8s secret name with the App credentials and other private info
                 type: string
@@ -72,12 +78,6 @@ spec:
                 type: object
               name:
                 type: string
-              state:
-                description: 'Specifies the current state of the app Valid values are: "STARTED": App is started "STOPPED": App is stopped'
-                enum:
-                - STARTED
-                - STOPPED
-                type: string
               type:
                 description: 'Specifies the CF Lifecycle type: https://v3-apidocs.cloudfoundry.org/version/3.101.0/index.html#sample-requests Valid values are: "docker": run prebuilt docker image "kpack": stage the app using kpack'
                 enum:
@@ -86,9 +86,9 @@ spec:
                 type: string
             required:
             - currentDropletRef
+            - desiredState
             - envSecretName
             - name
-            - state
             type: object
           status:
             description: AppStatus defines the observed state of App

--- a/config/samples/cf-crds/app.yaml
+++ b/config/samples/cf-crds/app.yaml
@@ -8,7 +8,7 @@ metadata:
     apps.cloudfoundry.org/appName: my-app-name
 spec:
   name: my-app-name
-  state: STARTED
+  desiredState: STARTED
   type: kpack
   lifecycle:
     data:

--- a/config/samples/cf-crds/process.yaml
+++ b/config/samples/cf-crds/process.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     apps.cloudfoundry.org/appGuid: my-app-guid
     apps.cloudfoundry.org/processGuid: my-process-guid
-    apps.cloudfoundry.org/processType: my-process-type
+    apps.cloudfoundry.org/processType: web
 spec:
   appRef:
     kind: App

--- a/controllers/process_controller.go
+++ b/controllers/process_controller.go
@@ -175,7 +175,7 @@ func (r *ProcessReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	} else if app.Spec.DesiredState == cfappsv1alpha1.StoppedState {
 		// delete the LRP if it exists and desired state is "STOPPED"
 		if lrpExists {
-			err := r.Client.Delete(context.Background(), existingLRP)
+			err := r.Client.Delete(ctx, existingLRP)
 			if err != nil {
 				logger.Info(fmt.Sprintf("Error occurred deleting LRP: %s, %s", process.Name, err))
 				return ctrl.Result{}, err

--- a/main.go
+++ b/main.go
@@ -171,6 +171,7 @@ func main() {
 		myRouter.HandleFunc(handlers.GetAppEndpoint, appHandler.GetAppHandler).Methods("GET")
 		myRouter.HandleFunc(handlers.AppsEndpoint, appHandler.ListAppsHandler).Methods("GET")
 		myRouter.HandleFunc(handlers.AppsEndpoint, appHandler.CreateAppsHandler).Methods("POST")
+		myRouter.HandleFunc(handlers.SetAppDesiredStateEndpoint, appHandler.SetAppDesiredStateHandler).Methods("POST")
 		myRouter.HandleFunc(handlers.GetAppEndpoint, appHandler.UpdateAppsHandler).Methods("PUT")
 		myRouter.HandleFunc(handlers.SetCurrentDroplet, appHandler.SetCurrentDroplet).Methods("PATCH")
 		myRouter.HandleFunc(handlers.GetPackageEndpoint, packageHandler.GetPackageHandler).Methods("GET")


### PR DESCRIPTION
https://github.com/cloudfoundry/cf-crd-explorations/issues/23

- renamed app.spec.state -> desiredState
- implemented endpoint POST /v3/apps/:guid/actions/start|stop
- modified process reconciler to delete LRP when app is STOPPED

Co-authored-by: Andrew Wittrock <awittrock@vmware.com>