### PR TITLE
Refine CRDs for wider shareout

### DIFF
--- a/config/samples/cf-crds-post-spike/app.yaml
+++ b/config/samples/cf-crds-post-spike/app.yaml
@@ -11,12 +11,10 @@ metadata:
 spec:
   name: my-app # validated to be unique per namespace by validating webhook
   envSecretName: "14dcda7d-1fa1-4a91-b437-fbdba20e8c5a-env" # the name of a secret containing a map of multiple environment variables passed to every Process of the App
-  currentDropletRef: # starts empty and is filled by CF Shim PATCH endpoint
-    apiVersion: "apps.cloudfoundry.org/v1alpha1"
-    kind: "CFDroplet"
+  currentDropletRef: # starts empty and is filled by CF Shim PATCH /v3/apps/:guid/current_droplet endpoint
     name: "1591ee05-e208-4cf3-a662-1c2da42f20a7"
   desiredState: STARTED
-  lifecycle: # taken from cf-for-k8s I think we should leave it with a note pointing out how it works in cf-for-k8s 
+  lifecycle:
     # We use this info to make a Builder per app: https://github.com/cloudfoundry/cloud_controller_ng/blob/a698d407d9f11263152cfdc4317f4786567bb16f/lib/cloud_controller/kpack/stager.rb#L153
     type: buildpack
     data:
@@ -28,7 +26,7 @@ status:
     status: "True"
     reason: Eirini
     message: "Processes are running"
-  - type: Restarting # Allows the us to implement the v3 restart app endpoint: https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#restart-an-app
+  - type: Restarting # Allows us to implement the v3 restart app endpoint: https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#restart-an-app
     status: "False"
     reason: Restarted
     message: "Restart was successful"

--- a/config/samples/cf-crds-post-spike/app.yaml
+++ b/config/samples/cf-crds-post-spike/app.yaml
@@ -1,0 +1,34 @@
+---
+# Defines the CF App
+apiVersion: apps.cloudfoundry.org/v1alpha1
+kind: CFApp
+metadata:
+  # apps.cloudfoundry.org/ labels are all managed by a mutating webhook
+  labels:
+    apps.cloudfoundry.org/appGuid: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+  name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+  namespace: default
+spec:
+  name: my-app # validated to be unique per namespace by validating webhook
+  envSecretName: "14dcda7d-1fa1-4a91-b437-fbdba20e8c5a-env" # the name of a secret containing a map of multiple environment variables passed to every Process of the App
+  currentDropletRef: # starts empty and is filled by CF Shim PATCH endpoint
+    apiVersion: "apps.cloudfoundry.org/v1alpha1"
+    kind: "CFDroplet"
+    name: "1591ee05-e208-4cf3-a662-1c2da42f20a7"
+  desiredState: STARTED
+  lifecycle: # taken from cf-for-k8s I think we should leave it with a note pointing out how it works in cf-for-k8s 
+    # We use this info to make a Builder per app: https://github.com/cloudfoundry/cloud_controller_ng/blob/a698d407d9f11263152cfdc4317f4786567bb16f/lib/cloud_controller/kpack/stager.rb#L153
+    type: buildpack
+    data:
+      buildpacks: []
+      stack: cflinuxfs3
+status:
+  conditions:
+  - type: Running
+    status: "True"
+    reason: Eirini
+    message: "Processes are running"
+  - type: Restarting # Allows the us to implement the v3 restart app endpoint: https://v3-apidocs.cloudfoundry.org/version/3.100.0/index.html#restart-an-app
+    status: "False"
+    reason: Restarted
+    message: "Restart was successful"

--- a/config/samples/cf-crds-post-spike/build.yaml
+++ b/config/samples/cf-crds-post-spike/build.yaml
@@ -25,10 +25,11 @@ spec:
     apiVersion: apps.cloudfoundry.org/v1alpha1
     kind: CFPackage
     name: ac85ad52-f52f-48e3-8c99-5e7badbe79c5
-  lifecycleData:
+  lifecycle:
     type: buildpack
-    buildpacks: []
-    stack: cflinuxfs3
+    data:
+      buildpacks: []
+      stack: cflinuxfs3
 status:
  conditions:
  - type: Succeeded

--- a/config/samples/cf-crds-post-spike/build.yaml
+++ b/config/samples/cf-crds-post-spike/build.yaml
@@ -18,12 +18,8 @@ metadata:
    uid: 2c5e9145-dee1-407f-b507-4ea84b25a7b4
 spec:
   appRef:
-    apiVersion: apps.cloudfoundry.org/v1alpha1
-    kind: CFApp
     name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
   packageRef:
-    apiVersion: apps.cloudfoundry.org/v1alpha1
-    kind: CFPackage
     name: ac85ad52-f52f-48e3-8c99-5e7badbe79c5
   lifecycle:
     type: buildpack
@@ -45,6 +41,4 @@ status:
    reason: Buildpack
    message: ""
  dropletRef: # This is used to support the droplet block of the GET Build endpoint of the CF V3 API
-   apiVersion: apps.cloudfoundry.org/v1alpha1
-   kind: CFDroplet
    name: 1591ee05-e208-4cf3-a662-1c2da42f20a7

--- a/config/samples/cf-crds-post-spike/build.yaml
+++ b/config/samples/cf-crds-post-spike/build.yaml
@@ -1,0 +1,49 @@
+---
+# Defines a build for the provided package. Triggers the staging process which results in a runnable container image. 
+# Successful CF Builds automatically receive CF Droplets.
+apiVersion: apps.cloudfoundry.org/v1alpha1
+kind: CFBuild
+metadata:
+  # apps.cloudfoundry.org/ labels are all managed by a mutating webhook
+  labels:
+    apps.cloudfoundry.org/appGuid: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+    apps.cloudfoundry.org/packageGuid: ac85ad52-f52f-48e3-8c99-5e7badbe79c5
+  name: 1591ee05-e208-4cf3-a662-1c2da42f20a7
+  namespace: default
+# ownerReferences are managed by mutating webhook that looks at appRef
+ ownerReferences:
+ - apiVersion: apps.cloudfoundry.org/v1alpha1
+   kind: CFApp
+   name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+   uid: 2c5e9145-dee1-407f-b507-4ea84b25a7b4
+spec:
+  appRef:
+    apiVersion: apps.cloudfoundry.org/v1alpha1
+    kind: CFApp
+    name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+  packageRef:
+    apiVersion: apps.cloudfoundry.org/v1alpha1
+    kind: CFPackage
+    name: ac85ad52-f52f-48e3-8c99-5e7badbe79c5
+  lifecycleData:
+    type: buildpack
+    buildpacks: []
+    stack: cflinuxfs3
+status:
+ conditions:
+ - type: Succeeded
+   status: "True"
+   reason: Buildpack
+   message: ""
+ - type: Staging
+   status: "False"
+   reason: Succeeded
+   message: ""
+ - type: Ready
+   status: "True"
+   reason: Buildpack
+   message: ""
+ dropletRef: # This is used to support the droplet block of the GET Build endpoint of the CF V3 API
+   apiVersion: apps.cloudfoundry.org/v1alpha1
+   kind: CFDroplet
+   name: 1591ee05-e208-4cf3-a662-1c2da42f20a7

--- a/config/samples/cf-crds-post-spike/droplet.yaml
+++ b/config/samples/cf-crds-post-spike/droplet.yaml
@@ -1,0 +1,41 @@
+---
+# A wrapper for an OCI-compliant, runnable image. Also contains ENTRYPOINT commands for Processes.
+apiVersion: apps.cloudfoundry.org/v1alpha1
+kind: CFDroplet
+metadata:
+  # apps.cloudfoundry.org/ labels are all managed by a mutating webhook
+  labels:
+    apps.cloudfoundry.org/appGuid: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+    apps.cloudfoundry.org/buildGuid: 1591ee05-e208-4cf3-a662-1c2da42f20a7
+  name: 1591ee05-e208-4cf3-a662-1c2da42f20a7
+  namespace: default
+# ownerReferences are managed by mutating webhook that looks at appRef
+ ownerReferences:
+ - apiVersion: apps.cloudfoundry.org/v1alpha1
+   kind: CFApp
+   name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+   uid: 2c5e9145-dee1-407f-b507-4ea84b25a7b4
+spec:
+  type: buildpack
+  appRef:
+    apiVersion: apps.cloudfoundry.org/v1alpha1
+    kind: CFApp
+    name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+  buildRef:
+    apiVersion: apps.cloudfoundry.org/v1alpha1
+    kind: CFBuild
+    name: 1591ee05-e208-4cf3-a662-1c2da42f20a7
+  ports: [80, 443] # spec.ports is the set of ports exposed on the Processes of the Droplet
+  processTypes:
+    web: bundle exec rackup config.ru -p $PORT -o 0.0.0.0
+    worker: bundle exec rackup config.ru
+  registry:
+    image: gcr.io/cf-relint-greengrass/cf-crd-staging-spike/buildpack/14dcda7d-1fa1-4a91-b437-fbdba20e8c5a@sha256:17ef1315d87bb57657ee14f387394f56d6f4429151262d731a31e92e5497ad35
+    imagePullSecrets:
+    - name: app-registry-credentials
+status:
+ conditions:
+ - type: Ready
+   status: "True"
+   reason: Buildpack
+   message: ""

--- a/config/samples/cf-crds-post-spike/droplet.yaml
+++ b/config/samples/cf-crds-post-spike/droplet.yaml
@@ -18,17 +18,15 @@ metadata:
 spec:
   type: buildpack
   appRef:
-    apiVersion: apps.cloudfoundry.org/v1alpha1
-    kind: CFApp
     name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
   buildRef:
-    apiVersion: apps.cloudfoundry.org/v1alpha1
-    kind: CFBuild
     name: 1591ee05-e208-4cf3-a662-1c2da42f20a7
   ports: [80, 443] # spec.ports is the set of ports exposed on the Processes of the Droplet
   processTypes:
-    web: bundle exec rackup config.ru -p $PORT -o 0.0.0.0
-    worker: bundle exec rackup config.ru
+    - type: web
+      command: bundle exec rackup config.ru -p $PORT -o 0.0.0.0
+    - type: worker
+      command: bundle exec rackup config.ru
   registry:
     image: gcr.io/cf-relint-greengrass/cf-crd-staging-spike/buildpack/14dcda7d-1fa1-4a91-b437-fbdba20e8c5a@sha256:17ef1315d87bb57657ee14f387394f56d6f4429151262d731a31e92e5497ad35
     imagePullSecrets:

--- a/config/samples/cf-crds-post-spike/package.yaml
+++ b/config/samples/cf-crds-post-spike/package.yaml
@@ -17,8 +17,6 @@ metadata:
 spec:
   type: bits
   appRef:
-    apiVersion: "apps.cloudfoundry.org/v1alpha1"
-    kind: "CFApp"
     name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a # Enforced via a Validating Webhook to reject empty or non-valid appRefs/appGUID
   source: # keeping this source block above registry gives us flexibility to support other kpack source types: https://github.com/pivotal/kpack/blob/main/docs/image.md#source-configuration
     registry:
@@ -26,7 +24,7 @@ spec:
       imagePullSecrets:
       - name: app-registry-credentials
 status:
-  conditions: # These should be managed by a controller, not the shim
+  conditions:
   - type: Succeeded
     status: "True"
     reason: Uploaded

--- a/config/samples/cf-crds-post-spike/package.yaml
+++ b/config/samples/cf-crds-post-spike/package.yaml
@@ -1,0 +1,41 @@
+---
+# Defines the CFPackage for “Bits/SourceBased” packages
+apiVersion: apps.cloudfoundry.org/v1alpha1
+kind: CFPackage
+metadata:
+  # apps.cloudfoundry.org/ labels are all managed by a mutating webhook
+  labels:
+    apps.cloudfoundry.org/appGuid: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+  name: ac85ad52-f52f-48e3-8c99-5e7badbe79c5
+  namespace: default
+# ownerReferences are managed by mutating webhook that looks at appRef
+ ownerReferences:
+ - apiVersion: apps.cloudfoundry.org/v1alpha1
+   kind: CFApp
+   name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+   uid: 2c5e9145-dee1-407f-b507-4ea84b25a7b4
+spec:
+  type: bits
+  appRef:
+    apiVersion: "apps.cloudfoundry.org/v1alpha1"
+    kind: "CFApp"
+    name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a # Enforced via a Validating Webhook to reject empty or non-valid appRefs/appGUID
+  source: # keeping this source block above registry gives us flexibility to support other kpack source types: https://github.com/pivotal/kpack/blob/main/docs/image.md#source-configuration
+    registry:
+      image: gcr.io/cf-relint-greengrass/cf-crd-staging-spike/packages/ac85ad52-f52f-48e3-8c99-5e7badbe79c5:latest
+      imagePullSecrets:
+      - name: app-registry-credentials
+status:
+  conditions: # These should be managed by a controller, not the shim
+  - type: Succeeded
+    status: "True"
+    reason: Uploaded
+    message: "Uploaded by CFShim"
+  - type: Ready
+    status: "True"
+    reason: Uploaded
+    message: "Uploaded by CFShim"
+  - type: Uploaded
+    status: "True"
+    reason: Uploaded
+    message: "Uploaded by CFShim"

--- a/config/samples/cf-crds-post-spike/process.yaml
+++ b/config/samples/cf-crds-post-spike/process.yaml
@@ -18,8 +18,6 @@ metadata:
     uid: 2c5e9145-dee1-407f-b507-4ea84b25a7b4
 spec:
   appRef:
-    apiVersion: apps.cloudfoundry.org/v1alpha1
-    kind: CFApp
     name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
   command: bundle exec rackup config.ru -p $PORT -o 0.0.0.0
   diskQuotaMB: 512

--- a/config/samples/cf-crds-post-spike/process.yaml
+++ b/config/samples/cf-crds-post-spike/process.yaml
@@ -1,0 +1,52 @@
+---
+# Defines a CFProcess for a given app. Results in an Eirini LRP.
+apiVersion: apps.cloudfoundry.org/v1alpha1
+kind: CFProcess
+metadata:
+  generation: 1
+  # apps.cloudfoundry.org/ labels are all managed by a mutating webhook based on appRef and its droplet
+  labels:
+    apps.cloudfoundry.org/appGuid: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+    apps.cloudfoundry.org/processGuid: my-app5-web
+    apps.cloudfoundry.org/processType: web
+  name: my-app5-web
+  namespace: default
+  # ownerReferences are managed by mutating webhook that looks at appRef
+  ownerReferences:
+  - apiVersion: apps.cloudfoundry.org/v1alpha1
+    kind: CFApp
+    name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+    uid: 2c5e9145-dee1-407f-b507-4ea84b25a7b4
+spec:
+  appRef:
+    apiVersion: apps.cloudfoundry.org/v1alpha1
+    kind: CFApp
+    name: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
+  command: bundle exec rackup config.ru -p $PORT -o 0.0.0.0
+  diskQuotaMB: 512
+  healthCheck:
+    type: process
+    data:
+      invocationTimeoutSeconds: 0
+      timeoutSeconds: 0
+  instances: 4 #desired instances
+  memoryMB: 500
+  ports:
+  - 8080
+  processType: web
+  state: STARTED
+status:
+  instances: 3 #actual running instances
+  conditions:
+  - type: Running
+    status: "True" # True if any replicas are running
+    reason: Eirini
+    message: "Process is running"
+  - type: Ready
+    status: "False"
+    reason: Eirini
+    message: "Not all processes are running"
+  - type: Restarting
+    status: "False"
+    reason: Restarted
+    message: "Restart was successful"

--- a/config/samples/cf-crds-post-spike/process.yaml
+++ b/config/samples/cf-crds-post-spike/process.yaml
@@ -3,7 +3,6 @@
 apiVersion: apps.cloudfoundry.org/v1alpha1
 kind: CFProcess
 metadata:
-  generation: 1
   # apps.cloudfoundry.org/ labels are all managed by a mutating webhook based on appRef and its droplet
   labels:
     apps.cloudfoundry.org/appGuid: 14dcda7d-1fa1-4a91-b437-fbdba20e8c5a
@@ -29,14 +28,13 @@ spec:
     data:
       invocationTimeoutSeconds: 0
       timeoutSeconds: 0
-  instances: 4 #desired instances
+  desiredInstances: 4 #desired instances
   memoryMB: 500
   ports:
   - 8080
   processType: web
-  state: STARTED
 status:
-  instances: 3 #actual running instances
+  runningInstances: 3 #actual running instances
   conditions:
   - type: Running
     status: "True" # True if any replicas are running


### PR DESCRIPTION
## Context
We've been iterating on the CF CRDs created in issue #1 in various spikes over the past few weeks. 

This PR includes revised examples of the cf-on-k8s CRs. In the process of implementing the initial spike, we have learned more about the CF domain and Kubernetes best practices. With that experience we have annotated the CRs here with comments to provide additional context and rationale behind changes.

## Feedback
We are hoping to get feedback regarding the CRDs with respect to the following areas:
- **Naming**: Does the naming of the CR and its fields make sense?
- **Intended User**: The CRs will be created and used almost exclusively by the CF Shim. However we may see kubectl users and K8s controllers occasionally viewing or modifying the CF CRs. What changes can we make to support this?
- **Ease of Change**: Consider how easy it is for the CR to change given the constraint of supporting the Cloud Foundry v3 API. An example of a change is swapping kpack or eirini in and out.
- **Conditions**: In Kubernetes, status.conditions are used to manage controller logic as well as communicate the current state of the resource to other interested parties. Do the Condition types and reasons make sense? Is something missing?

## Issue
https://github.com/cloudfoundry/cf-crd-explorations/issues/12

Co-authored-by: Akira Wong <wakira@vmware.com>