### PR TITLE
Prepare for archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# ⚠️ Archived ⚠️
+
+This repo is no longer being used. Development is actively underway on https://github.com/cloudfoundry/cf-k8s-controllers and any future exploration will take place on that repo as well.
+
 # cf-crd-explorations
 
 ⚠️ **This Repository is for Experimentation Only** ⚠️


### PR DESCRIPTION
As discussed in the CF on K8s SIG Meeting, we will be archiving this repo in favor of doing future exploratory work directly on https://github.com/cloudfoundry/cf-k8s-controllers.